### PR TITLE
Pass context everywhere

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -11,7 +11,7 @@ import (
 )
 
 // RunMigrationsFunc is a function that runs migrations
-type RunMigrationsFunc func(ds datastore.Batching, migrations versioning.VersionedMigrationList, target versioning.VersionKey) (versioning.VersionKey, error)
+type RunMigrationsFunc func(ctx context.Context, ds datastore.Batching, migrations versioning.VersionedMigrationList, target versioning.VersionKey) (versioning.VersionKey, error)
 
 // Runner executes a migrations exactly once
 // and can queried for status of that migration and any migration errors
@@ -41,7 +41,7 @@ func NewRunner(ds datastore.Batching, migrations versioning.VersionedMigrationLi
 func (m *Runner) Migrate(ctx context.Context) error {
 	go func() {
 		m.doMigration.Do(func() {
-			_, err := m.runMigrations(m.ds, m.migrations, m.target)
+			_, err := m.runMigrations(ctx, m.ds, m.migrations, m.target)
 			m.migrationError.Store(err)
 			m.ready.Store(true)
 			close(m.migrationsDone)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -33,7 +33,7 @@ func TestMigrate(t *testing.T) {
 			},
 			getRunMigrations: func(param interface{}) runner.RunMigrationsFunc {
 				count := param.(*atomic.Uint64)
-				return func(datastore.Batching, versioning.VersionedMigrationList, versioning.VersionKey) (versioning.VersionKey, error) {
+				return func(context.Context, datastore.Batching, versioning.VersionedMigrationList, versioning.VersionKey) (versioning.VersionKey, error) {
 					count.Inc()
 					return versioning.VersionKey(""), nil
 				}
@@ -49,7 +49,7 @@ func TestMigrate(t *testing.T) {
 				assert.EqualError(t, r.ReadyError(), versioning.ErrMigrationsNotRun.Error())
 			},
 			getRunMigrations: func(param interface{}) runner.RunMigrationsFunc {
-				return func(datastore.Batching, versioning.VersionedMigrationList, versioning.VersionKey) (versioning.VersionKey, error) {
+				return func(context.Context, datastore.Batching, versioning.VersionedMigrationList, versioning.VersionKey) (versioning.VersionKey, error) {
 					return versioning.VersionKey(""), nil
 				}
 			},
@@ -63,7 +63,7 @@ func TestMigrate(t *testing.T) {
 				assert.EqualError(t, r.ReadyError(), versioning.ErrMigrationsNotRun.Error())
 			},
 			getRunMigrations: func(param interface{}) runner.RunMigrationsFunc {
-				return func(datastore.Batching, versioning.VersionedMigrationList, versioning.VersionKey) (versioning.VersionKey, error) {
+				return func(context.Context, datastore.Batching, versioning.VersionedMigrationList, versioning.VersionKey) (versioning.VersionKey, error) {
 					return versioning.VersionKey(""), errors.New("something went wrong")
 				}
 			},
@@ -82,7 +82,7 @@ func TestMigrate(t *testing.T) {
 			},
 			getRunMigrations: func(param interface{}) runner.RunMigrationsFunc {
 				blocker := param.(chan struct{})
-				return func(datastore.Batching, versioning.VersionedMigrationList, versioning.VersionKey) (versioning.VersionKey, error) {
+				return func(context.Context, datastore.Batching, versioning.VersionedMigrationList, versioning.VersionKey) (versioning.VersionKey, error) {
 					<-blocker
 					return versioning.VersionKey(""), nil
 				}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"context"
 	"errors"
 	"reflect"
 
@@ -77,8 +78,8 @@ type dsMigration struct {
 	upFunc  reflect.Value
 }
 
-func (dm *dsMigration) Up(oldDs datastore.Batching, newDS datastore.Batching) ([]datastore.Key, error) {
-	return migrate.Execute(dm.query, oldDs, newDS, dm.oldType, dm.upFunc)
+func (dm *dsMigration) Up(ctx context.Context, oldDs datastore.Batching, newDS datastore.Batching) ([]datastore.Key, error) {
+	return migrate.Execute(ctx, dm.query, oldDs, newDS, dm.oldType, dm.upFunc)
 }
 
 type reversibleDsMigration struct {
@@ -86,8 +87,8 @@ type reversibleDsMigration struct {
 	downFunc reflect.Value
 }
 
-func (rdm *reversibleDsMigration) Down(newDs datastore.Batching, oldDs datastore.Batching) ([]datastore.Key, error) {
-	return migrate.Execute(rdm.query, newDs, oldDs, rdm.newType, rdm.downFunc)
+func (rdm *reversibleDsMigration) Down(ctx context.Context, newDs datastore.Batching, oldDs datastore.Batching) ([]datastore.Key, error) {
+	return migrate.Execute(ctx, rdm.query, newDs, oldDs, rdm.newType, rdm.downFunc)
 }
 
 // NewMigrationBuilder returns an interface that can be used to build a data base migration

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -2,6 +2,7 @@ package builder_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"testing"
 
@@ -15,6 +16,7 @@ import (
 )
 
 func TestExecuteMigration(t *testing.T) {
+	ctx := context.Background()
 	var appleCount = cbg.CborInt(30)
 	var orangeCount = cbg.CborInt(0)
 	var changedAppleCount = cbg.CborInt(37)
@@ -114,7 +116,7 @@ func TestExecuteMigration(t *testing.T) {
 			if data.expectedErr == nil {
 				require.NoError(t, err)
 
-				_, err = migration.Up(ds1, ds2)
+				_, err = migration.Up(ctx, ds1, ds2)
 				require.NoError(t, err)
 
 				outputDatabase := make(map[string]*cbg.CborInt)
@@ -137,7 +139,7 @@ func TestExecuteMigration(t *testing.T) {
 				reversible, ok := migration.(versioning.ReversableDatastoreMigration)
 				if ok {
 					ds3 := datastore.NewMapDatastore()
-					_, err = reversible.Down(ds2, ds3)
+					_, err = reversible.Down(ctx, ds2, ds3)
 					require.NoError(t, err)
 
 					reversedDatabase := make(map[string]*cbg.CborInt)

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -1,6 +1,10 @@
 package versioning
 
-import "github.com/ipfs/go-datastore"
+import (
+	"context"
+
+	"github.com/ipfs/go-datastore"
+)
 
 // MigrationFunc is a function to transform an single element of one type of data into
 // a single element of another type of data. It has the following form:
@@ -11,13 +15,13 @@ type MigrationFunc interface{}
 // of one kind of structured data and write it to a table that is another kind of
 // structured data
 type DatastoreMigration interface {
-	Up(oldDs datastore.Batching, newDS datastore.Batching) ([]datastore.Key, error)
+	Up(ctx context.Context, oldDs datastore.Batching, newDS datastore.Batching) ([]datastore.Key, error)
 }
 
 // ReversableDatastoreMigration is
 type ReversableDatastoreMigration interface {
 	DatastoreMigration
-	Down(newDs datastore.Batching, oldDS datastore.Batching) ([]datastore.Key, error)
+	Down(ctx context.Context, newDs datastore.Batching, oldDS datastore.Batching) ([]datastore.Key, error)
 }
 
 // VersionKey is an identifier for a databased version
@@ -28,14 +32,14 @@ type VersionKey string
 type VersionedMigration interface {
 	OldVersion() VersionKey
 	NewVersion() VersionKey
-	Up(ds datastore.Batching) ([]datastore.Key, error)
+	Up(ctx context.Context, ds datastore.Batching) ([]datastore.Key, error)
 }
 
 // ReversibleVersionedMigration is a migration that migrates data in a single database
 // between versions, and can be reversed
 type ReversibleVersionedMigration interface {
 	VersionedMigration
-	Down(ds datastore.Batching) ([]datastore.Key, error)
+	Down(ctx context.Context, ds datastore.Batching) ([]datastore.Key, error)
 }
 
 // VersionedMigrationList is a sortable list of versioned migrations

--- a/pkg/versioned/versioned_test.go
+++ b/pkg/versioned/versioned_test.go
@@ -2,6 +2,7 @@ package versioned_test
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	cborutil "github.com/filecoin-project/go-cbor-util"
@@ -16,6 +17,7 @@ import (
 )
 
 func TestExecuteMigration(t *testing.T) {
+	ctx := context.Background()
 	var appleCount = cbg.CborInt(30)
 	var orangeCount = cbg.CborInt(0)
 	var changedAppleCount = cbg.CborInt(37)
@@ -75,7 +77,7 @@ func TestExecuteMigration(t *testing.T) {
 				}
 			}
 
-			keys, err := data.versionedMigration.Up(ds1)
+			keys, err := data.versionedMigration.Up(ctx, ds1)
 			require.NoError(t, err)
 
 			batch, err := ds1.Batch()
@@ -103,7 +105,7 @@ func TestExecuteMigration(t *testing.T) {
 			}
 			require.Equal(t, data.expectedOutputDatabase, outputDatabase)
 
-			keys, err = data.versionedMigration.Down(ds1)
+			keys, err = data.versionedMigration.Down(ctx, ds1)
 			require.NoError(t, err)
 
 			batch, err = ds1.Batch()


### PR DESCRIPTION
# Goals

Migrations should stop where they are when context is cancelled, cleaning of the most recent migration and then ending

# Implementation

- pass context everywhere
- in the actual migration, after each record migration, check if context is cancelled
- the logic of migrate.To will mean a cancelled context in the middle of the migration means that migration will stop and the partially migrated database will be deleted 
