### PR TITLE
add empty migrations check

### DIFF
--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -97,6 +97,9 @@ var versioningKey = datastore.NewKey("/versions/current")
 // and applying migrations as need to reach the target version
 // it returns the final database version (ideally = target) and any errors encountered
 func To(ctx context.Context, ds datastore.Batching, migrations versioning.VersionedMigrationList, to versioning.VersionKey) (versioning.VersionKey, error) {
+	if len(migrations) == 0 {
+		return versioning.VersionKey(""), fmt.Errorf("empty migrations list")
+	}
 	sort.Sort(migrations)
 	if !verifyIntegrity(migrations) {
 		return versioning.VersionKey(""), fmt.Errorf("migrations list must be contiguous")


### PR DESCRIPTION
The [`To`](https://github.com/filecoin-project/go-ds-versioning/blob/508abd7c2aff857874515bd9496baad4a1e217d7/internal/migrate/migrate.go#L99) function does not handle the case where `migrations` is an empty list and it eventually panics if that is the case. This PR catches that case and handles it.

Related to https://github.com/application-research/estuary/issues/158